### PR TITLE
Add more flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 lib/
 docs/
 *.tgz
+
+/.idea

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # @geoblocks/geoblocks changes
 
+## 0.2.3
+- In `BaseCustomizer`, the printExtent can be now set and get/set are dedicated methods.
+- `pdfA` (allow transparency) is now a spec.map optional param.
+- spec.attributes are now partial and `datasources` attribute is removed.
+- CreateSpecOptions accepts now every format.
+
+## v0.2.2
+- Add optional MVTEncoder
+
 ## v0.2.0
 - General refactor (rename classes / types)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,9 @@
 - Add utility functions.
 - In `BaseCustomizer`, the printExtent can be now set and get/set are dedicated methods.
 - `pdfA` (allow transparency) is now a spec.map optional param.
-- spec.attributes are now partial and `datasources` attribute is removed.
+- spec.attributes are now partial and `datasource` attribute is removed.
 - CreateSpecOptions accepts now every format.
+- Add a timeout and manage errors on the `getDownloadUrl` utils function.
 
 ## v0.2.2
 - Add optional MVTEncoder

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # @geoblocks/geoblocks changes
 
 ## 0.2.3
+- Add utility functions.
 - In `BaseCustomizer`, the printExtent can be now set and get/set are dedicated methods.
 - `pdfA` (allow transparency) is now a spec.map optional param.
 - spec.attributes are now partial and `datasources` attribute is removed.

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -34,7 +34,7 @@ document.querySelector('#print').addEventListener('click', async () => {
     dpi: 254,
     layout: layout,
     format: 'pdf',
-    customAttributes: {},
+    customAttributes: {datasource: []},
     customizer: customizer,
   });
 
@@ -54,10 +54,10 @@ document.querySelector('#print').addEventListener('click', async () => {
       document.location = url;
       return url;
     },
-    (err) => {
-      console.log('result', 'error', err);
-      resultEl.innerHTML = 'Error';
-      return err;
+    (error) => {
+      console.log('result', 'error', error);
+      resultEl.innerHTML = error;
+      return error;
     },
   );
 });

--- a/src/BaseCustomizer.ts
+++ b/src/BaseCustomizer.ts
@@ -10,14 +10,17 @@ import type {Feature as GeoJSONFeature} from 'geojson';
  * It also defines the print extent.
  */
 export default class BaseCustomizer {
-  readonly printExtent: number[];
+  private printExtent: number[];
 
-  /**
-   *
-   * @param printExtent The extent to print (useful for MVT / static image layers)
-   */
-  constructor(printExtent: number[]) {
-    // FIXME: can not this be passed with the other options in createSpec?
+  constructor(printExtent?: number[]) {
+    this.setPrintExtent(printExtent || [0, 0, Infinity, Infinity]);
+  }
+
+  getPrintExtent(): number[] {
+    return this.printExtent;
+  }
+
+  setPrintExtent(printExtent: number[]) {
     this.printExtent = printExtent;
   }
 

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -37,7 +37,7 @@ export interface CreateSpecOptions {
   printResolution: number;
   dpi: number;
   layout: string;
-  format: 'pdf' | 'jpg' | 'png';
+  format: string;
   customAttributes: Record<string, any>;
   customizer: BaseCustomizer;
 }
@@ -80,7 +80,6 @@ export default class MFPBaseEncoder {
     });
     const attributes: MFPAttributes = {
       map: mapSpec,
-      datasource: [],
     };
     Object.assign(attributes, options.customAttributes);
 
@@ -104,16 +103,14 @@ export default class MFPBaseEncoder {
     const mapLayerGroup = options.map.getLayerGroup();
     const layers = await this.encodeLayerGroup(mapLayerGroup, options.printResolution, options.customizer);
 
-    const spec = {
+    return {
       center,
       dpi: options.dpi,
-      pdfA: false,
       projection,
       rotation,
       scale: options.scale,
       layers,
-    } as MFPMap;
-    return spec;
+    };
   }
 
   /**
@@ -203,13 +200,13 @@ export default class MFPBaseEncoder {
     const layer = layerState.layer as VectorTileLayer;
     const {MVTEncoder} = await import('@geoblocks/print');
     const encoder = new MVTEncoder();
-    const printExtent = customizer.printExtent;
+    const printExtent = customizer.getPrintExtent();
     const width = getExtentWidth(printExtent) / printResolution;
     const height = getExtentHeight(printExtent) / printResolution;
     const canvasSize: [number, number] = [width, height];
     const printOptions = {
       layer,
-      printExtent: customizer.printExtent,
+      printExtent: customizer.getPrintExtent(),
       tileResolution: printResolution,
       styleResolution: printResolution,
       canvasSize: canvasSize,
@@ -315,7 +312,7 @@ export default class MFPBaseEncoder {
     additionalDraw: (cir: VectorContext, geometry: Geometry) => void,
   ): Promise<MFPImageLayer> {
     const layer = layerState.layer as VectorLayer<VectorSource>;
-    const printExtent = customizer.printExtent;
+    const printExtent = customizer.getPrintExtent();
     const width = getExtentWidth(printExtent) / resolution;
     const height = getExtentHeight(printExtent) / resolution;
     const size: [number, number] = [width, height];

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -81,7 +81,7 @@ export default class VectorEncoder {
     }
     console.assert(source instanceof VectorSource);
 
-    const features = source.getFeaturesInExtent(this.customizer_.printExtent);
+    const features = source.getFeaturesInExtent(this.customizer_.getPrintExtent());
 
     const geojsonFeatures: GeoJSONFeature[] = [];
     const mapfishStyleObject: MFPVectorStyle = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,13 @@
 export const Constants = {
   /** "Standardized rendering pixel size" is defined as 0.28 mm, see http://www.opengeospatial.org/standards/wmts */
   WMTS_PIXEL_SIZE: 0.28e-3,
-  /** Standard PPI */
-  POINTS_PER_INCH: 72,
+  /** Standard DPI */
+  DOTS_PER_INCH: 72,
   /** According to the "international yard" definition 1 inch is defined as exactly 2.54 cm. */
   METERS_PER_INCH: 0.0254,
 };
 
 export const CalculatedConstants = {
-  /** Default to PPI / METERS per Inch */
-  POINTS_PER_DISTANCE_UNIT: () => Constants.POINTS_PER_INCH / Constants.METERS_PER_INCH,
+  /** Default to DPI / METERS per Inch */
+  DPI_PER_DISTANCE_UNIT: () => Constants.DOTS_PER_INCH / Constants.METERS_PER_INCH,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+export const Constants = {
+  /** "Standardized rendering pixel size" is defined as 0.28 mm, see http://www.opengeospatial.org/standards/wmts */
+  WMTS_PIXEL_SIZE: 0.28e-3,
+  /** Standard PPI */
+  POINTS_PER_INCH: 72,
+  /** According to the "international yard" definition 1 inch is defined as exactly 2.54 cm. */
+  METERS_PER_INCH: 0.0254,
+};
+
+export const CalculatedConstants = {
+  /** Default to PPI / METERS per Inch */
+  POINTS_PER_DISTANCE_UNIT: () => Constants.POINTS_PER_INCH / Constants.METERS_PER_INCH,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,7 @@ export interface MFPStatusResponse {
   done: boolean;
   downloadURL: string;
   elapsedTime: number;
+  error?: string;
   status: string;
   waitingTime: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,17 +124,16 @@ export interface MFPMap {
   projection: string;
   rotation: number;
   useNearestScale?: boolean;
+  /* Allow transparency property. Default to false */
+  pdfA?: boolean;
 }
 
 export interface MFPAttributes {
   map: MFPMap;
-  // FIXME: I don't know what to put here
-  // See http://mapfish.github.io/mapfish-print-doc/attributes.html#!datasource
-  datasource: any[];
 }
 
 export interface MFPSpec {
-  attributes: MFPAttributes;
+  attributes: Partial<MFPAttributes>;
   layout: string;
   format: string;
   smtp?: Record<string, string>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,14 +6,14 @@ import type {Extent} from 'ol/extent';
 import {Constants, CalculatedConstants} from './constants';
 
 /**
- * @param mapPageSize The page size (width, height)
+ * @param mapPageSize The page size in pixels (width, height)
  * @param center The coordinate of the extent's center.
  * @param scale The scale to calculate the extent width.
- * @returns an extent that fit the page size. Calculated with POINTS_PER_DISTANCE_UNIT (by default using meters)
+ * @returns an extent that fit the page size. Calculated with DPI_PER_DISTANCE_UNIT (by default using meters)
  */
 export function getPrintExtent(mapPageSize: number[], center: number[], scale: number): Extent {
   const [mapPageWidthMeters, mapPageHeightMeters] = mapPageSize.map(
-    (side) => ((side / CalculatedConstants.POINTS_PER_DISTANCE_UNIT()) * scale) / 2,
+    (side) => ((side / CalculatedConstants.DPI_PER_DISTANCE_UNIT()) * scale) / 2,
   );
   return [
     center[0] - mapPageWidthMeters,
@@ -118,19 +118,39 @@ export async function requestReport(mfpBaseUrl: string, spec: MFPSpec): Promise<
   return await report.json();
 }
 
-// FIXME: add timeout
-// FIXME: handle errors
+/**
+ * @param requestReport the name of the requested report
+ * @param response The initial print response.
+ * @param interval (s) the internal to poll the download url.
+ * @param timeout (s) A timeout for this operation.
+ * @returns a Promise with the download url once the document is printed or an error.
+ */
 export async function getDownloadUrl(
   requestReport: string,
   response: MFPReportResponse,
   interval = 1000,
+  timeout = 30000,
 ): Promise<string> {
+  let totalDuration = 0 - interval;
   return new Promise((resolve, reject) => {
     const intervalId = setInterval(async () => {
-      const status = await getStatus(requestReport, response.ref);
+      let status: MFPStatusResponse | undefined;
+      try {
+        status = await getStatus(requestReport, response.ref);
+        if (status.error) {
+          throw new Error(status.error);
+        }
+      } catch (error) {
+        reject(error);
+      }
       if (status.done) {
         clearInterval(intervalId);
         resolve(`${requestReport}/report/${response.ref}`);
+      }
+      totalDuration += interval;
+      if (totalDuration >= timeout) {
+        clearInterval(intervalId);
+        reject(new Error('Print duration exceeded'));
       }
     }, interval);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,26 @@ import WMTSTileGrid from 'ol/tilegrid/WMTS.js';
 import {toSize} from 'ol/size.js';
 import type {MFPReportResponse, MFPSpec, MFPStatusResponse, MFPWmtsMatrix} from './types';
 import type {WMTS} from 'ol/source.js';
+import type {Extent} from 'ol/extent';
+import {Constants, CalculatedConstants} from './constants';
 
-// "Standardized rendering pixel size" is defined as 0.28 mm, see http://www.opengeospatial.org/standards/wmts
-const WMTS_PIXEL_SIZE_ = 0.28e-3;
+/**
+ * @param mapPageSize The page size (width, height)
+ * @param center The coordinate of the extent's center.
+ * @param scale The scale to calculate the extent width.
+ * @returns an extent that fit the page size. Calculated with POINTS_PER_DISTANCE_UNIT (by default using meters)
+ */
+export function getPrintExtent(mapPageSize: number[], center: number[], scale: number): Extent {
+  const [mapPageWidthMeters, mapPageHeightMeters] = mapPageSize.map(
+    (side) => ((side / CalculatedConstants.POINTS_PER_DISTANCE_UNIT()) * scale) / 2,
+  );
+  return [
+    center[0] - mapPageWidthMeters,
+    center[1] - mapPageHeightMeters,
+    center[0] + mapPageWidthMeters,
+    center[1] + mapPageHeightMeters,
+  ];
+}
 
 /**
  * Takes a hex value and prepends a zero if it's a single digit.
@@ -51,7 +68,7 @@ export function getWmtsMatrices(source: WMTS): MFPWmtsMatrix[] {
     const resolutionMeters = tileGrid.getResolution(i) * metersPerUnit;
     wmtsMatrices.push({
       identifier: matrixIds[i],
-      scaleDenominator: resolutionMeters / WMTS_PIXEL_SIZE_,
+      scaleDenominator: resolutionMeters / Constants.WMTS_PIXEL_SIZE,
       tileSize: toSize(tileGrid.getTileSize(i)),
       topLeftCorner: tileGrid.getOrigin(i),
       matrixSize: [tileRange.maxX - tileRange.minX, tileRange.maxY - tileRange.minY],

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ test('Empty map', async (t) => {
     dpi: 300,
     layout: 'landscape_a4',
     format: 'pdf',
-    customAttributes: {},
+    customAttributes: {title: 'My title'},
     customizer: customizer,
   });
   assert.deepEqual(result, {
@@ -38,6 +38,7 @@ test('Empty map', async (t) => {
         rotation: 0,
         scale: 1,
       },
+      title: 'My title',
     },
     format: 'pdf',
     layout: 'landscape_a4',
@@ -45,7 +46,7 @@ test('Empty map', async (t) => {
 });
 
 test('OSM map', async (t) => {
-  const MFP_URL = 'https://geomapfish-demo-2-5.camptocamp.com/printproxy';
+  const MFP_URL = 'https://geomapfish-demo-2-8.camptocamp.com/printproxy';
   const layout = '1 A4 portrait'; // better take from MFP
   const map = new Map({
     target: 'map',

--- a/test.js
+++ b/test.js
@@ -30,12 +30,10 @@ test('Empty map', async (t) => {
   });
   assert.deepEqual(result, {
     attributes: {
-      datasource: [],
       map: {
         center: [796612.417322277, 5836960.776101627],
         dpi: 300,
         layers: [],
-        pdfA: false,
         projection: 'EPSG:3857',
         rotation: 0,
         scale: 1,
@@ -78,7 +76,6 @@ test('OSM map', async (t) => {
 
   assert.deepEqual(spec, {
     attributes: {
-      datasource: [],
       map: {
         center: [796612.417322277, 5836960.776101627],
         dpi: 254,
@@ -90,7 +87,6 @@ test('OSM map', async (t) => {
             type: 'osm',
           },
         ],
-        pdfA: false,
         projection: 'EPSG:3857',
         rotation: 0,
         scale: 1,


### PR DESCRIPTION
Draft for #14 , points:

- [x] 1 Remove useless option pdfA => it's optional and means "Allow transparancy" => add doc
- [x] 2 Remove hardcoded datasources in attributes 
- [x] 3 Add dynamic attributes (title, comments, foobar,  <others> etc) as options of attributes
- [x] 9 Don't limit print format to 'pdf' | 'jpg' | 'png'.  (CreateSpecOptions)
- [x] 4 Add a possibility to set the extent in the BaseCustomizer
- [x] 8 Add a getExtent function (with map center, scale, angle, paperSize, PointPerInch, MeterPerInch)
- [x] 5 Add a timeout and error management on the getDownloadUrl method.