### PR TITLE
Move out createSpec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # @geoblocks/geoblocks changes
 
+## 0.2.4
+- Move createReport to utils.
+
 ## 0.2.3
 - Add utility functions.
 - In `BaseCustomizer`, the printExtent can be now set and get/set are dedicated methods.

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -27,16 +27,28 @@ document.querySelector('#print').addEventListener('click', async () => {
   specEl.innerHTML = reportEl.innerHTML = resultEl.innerHTML = '';
   const encoder = new MFPEncoder(MFP_URL);
   const customizer = new BaseCustomizer([0, 0, 10000, 10000]);
-  const spec = await encoder.createSpec({
+  /**
+   * @type {MFPMap}
+   */
+  const mapSpec = await encoder.encodeMap({
     map,
     scale: 1,
     printResolution: 96,
     dpi: 254,
-    layout: layout,
-    format: 'pdf',
-    customAttributes: {datasource: []},
     customizer: customizer,
   });
+
+  /**
+   * @type {MFPSpec}
+   */
+  const spec = {
+    attributes: {
+      map: mapSpec,
+      datasource: [],
+    },
+    format: 'pdf',
+    layout: layout,
+  };
 
   // This is just a quick demo
   // Note that using innerHTML is not a good idea in production code...

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -9,15 +9,7 @@ import {getWidth as getExtentWidth, getHeight as getExtentHeight} from 'ol/exten
 
 import BaseCustomizer from './BaseCustomizer';
 import type Map from 'ol/Map.js';
-import type {
-  MFPAttributes,
-  MFPImageLayer,
-  MFPLayer,
-  MFPMap,
-  MFPOSMLayer,
-  MFPSpec,
-  MFPWmtsLayer,
-} from './types';
+import type {MFPImageLayer, MFPLayer, MFPMap, MFPOSMLayer, MFPWmtsLayer} from './types';
 import type WMTS from 'ol/source/WMTS.js';
 
 import type {Geometry} from 'ol/geom.js';
@@ -30,17 +22,6 @@ import {toContext} from 'ol/render.js';
 import VectorSource from 'ol/source/Vector.js';
 import LayerGroup from 'ol/layer/Group';
 import VectorContext from 'ol/render/VectorContext';
-
-export interface CreateSpecOptions {
-  map: Map;
-  scale: number;
-  printResolution: number;
-  dpi: number;
-  layout: string;
-  format: string;
-  customAttributes: Record<string, any>;
-  customizer: BaseCustomizer;
-}
 
 export interface EncodeMapOptions {
   map: Map;
@@ -63,31 +44,6 @@ export default class MFPBaseEncoder {
    */
   constructor(printUrl: string) {
     this.url = printUrl;
-  }
-
-  /**
-   * Introspect the map and convert each of its layers to Mapfish print v3 format.
-   * @param options
-   * @return a top level Mapfish print spec
-   */
-  async createSpec(options: CreateSpecOptions): Promise<MFPSpec> {
-    const mapSpec = await this.encodeMap({
-      map: options.map,
-      scale: options.scale,
-      printResolution: options.printResolution,
-      dpi: options.dpi,
-      customizer: options.customizer,
-    });
-    const attributes: MFPAttributes = {
-      map: mapSpec,
-    };
-    Object.assign(attributes, options.customAttributes);
-
-    return {
-      attributes,
-      format: options.format,
-      layout: options.layout,
-    };
   }
 
   /**

--- a/test.js
+++ b/test.js
@@ -18,36 +18,25 @@ test('Empty map', async (t) => {
     }),
   });
   map.getView();
-  const result = await encoder.createSpec({
+  const result = await encoder.encodeMap({
     map,
     scale: 1,
     printResolution: 96,
     dpi: 300,
-    layout: 'landscape_a4',
-    format: 'pdf',
-    customAttributes: {title: 'My title'},
     customizer: customizer,
   });
   assert.deepEqual(result, {
-    attributes: {
-      map: {
-        center: [796612.417322277, 5836960.776101627],
-        dpi: 300,
-        layers: [],
-        projection: 'EPSG:3857',
-        rotation: 0,
-        scale: 1,
-      },
-      title: 'My title',
-    },
-    format: 'pdf',
-    layout: 'landscape_a4',
+    center: [796612.417322277, 5836960.776101627],
+    dpi: 300,
+    layers: [],
+    projection: 'EPSG:3857',
+    rotation: 0,
+    scale: 1,
   });
 });
 
 test('OSM map', async (t) => {
   const MFP_URL = 'https://geomapfish-demo-2-8.camptocamp.com/printproxy';
-  const layout = '1 A4 portrait'; // better take from MFP
   const map = new Map({
     target: 'map',
     layers: [
@@ -64,36 +53,27 @@ test('OSM map', async (t) => {
 
   const encoder = new MyMfpBaseEncoder(MFP_URL);
   const customizer = new BaseCustomizer([0, 0, 10000, 10000]);
-  const spec = await encoder.createSpec({
+  const spec = await encoder.encodeMap({
     map,
     scale: 1,
     printResolution: 96,
     dpi: 254,
-    layout: layout,
-    format: 'pdf',
-    customAttributes: {},
     customizer: customizer,
   });
 
   assert.deepEqual(spec, {
-    attributes: {
-      map: {
-        center: [796612.417322277, 5836960.776101627],
-        dpi: 254,
-        layers: [
-          {
-            baseURL: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-            name: undefined,
-            opacity: 1,
-            type: 'osm',
-          },
-        ],
-        projection: 'EPSG:3857',
-        rotation: 0,
-        scale: 1,
+    center: [796612.417322277, 5836960.776101627],
+    dpi: 254,
+    layers: [
+      {
+        baseURL: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        name: undefined,
+        opacity: 1,
+        type: 'osm',
       },
-    },
-    format: 'pdf',
-    layout: layout,
+    ],
+    projection: 'EPSG:3857',
+    rotation: 0,
+    scale: 1,
   });
 });


### PR DESCRIPTION
This simplifies and rationalize the API:
- the encoder is about encoding OL objects;
- it does not need to know about the actual layout / attributes;
- utils are for interacting with the server.