### PR TITLE
Add wms image raw implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.2.4
 - Move createReport to utils.
+- Add **raw** encode support for WMS and Tile WMS layers.
 
 ## 0.2.3
 - Add utility functions.

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -32,8 +32,8 @@ document.querySelector('#print').addEventListener('click', async () => {
    */
   const mapSpec = await encoder.encodeMap({
     map,
-    scale: 1,
-    printResolution: 96,
+    scale: 10000,
+    printResolution: map.getView().getResolution(),
     dpi: 254,
     customizer: customizer,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,21 @@ export interface MFPWmtsLayer extends MFPLayer {
   version: string;
 }
 
+export interface MFPWmsLayer extends MFPLayer {
+  type: 'wms';
+  baseURL: string;
+  imageFormat: string;
+  layers: string[];
+  customParams: Record<string, string>;
+  /** The server type ("mapserver", "geoserver" or "qgisserver"). */
+  serverType: string;
+  opacity: number;
+  version: string;
+  styles: string[];
+  /** For GeoServer, and MapServer, ask the map server to do the rotation. */
+  useNativeAngle: boolean;
+}
+
 export interface MFPImageLayer extends MFPLayer {
   type: 'image';
   extent: number[];

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ test('Empty map', async (t) => {
   const result = await encoder.encodeMap({
     map,
     scale: 1,
-    printResolution: 96,
+    printResolution: map.getView().getResolution(),
     dpi: 300,
     customizer: customizer,
   });
@@ -56,7 +56,7 @@ test('OSM map', async (t) => {
   const spec = await encoder.encodeMap({
     map,
     scale: 1,
-    printResolution: 96,
+    printResolution: map.getView().getResolution(),
     dpi: 254,
     customizer: customizer,
   });


### PR DESCRIPTION
Inspired (or more) by https://github.com/camptocamp/ngeo/blob/master/src/print/Service.js#L248

That's probably not very generic (maybe not working), but at least you probably only have to redefine `encodeWmsLayerState` to have your layer.
I think we can also better use the (unused) customizer,.

It will be improved by testing it on a real project.