### PR TITLE
Add ol version 9 in peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@geoblocks/print": "0.7"
   },
   "peerDependencies": {
-    "ol": "6 || 7 || 8"
+    "ol": "6 || 7 || 8 || 9"
   },
   "devDependencies": {
     "@geoblocks/print": "0.7.4",


### PR DESCRIPTION
Because my project use OL 9.

See the error [here](https://eu-central-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiMnBGSVBmL3oydGF6WjNCd2JyVE9JZ09Ka2R1QVRTQVMydVg0Wnc2aDJhaFU4V0Q2bGJNMktVaUtwaGF3dFBBMEkzTWNXVytJR1d1Ri9DTU1PVndTNE5BaFFaV0cyeEorN0tHNUJOaG5wcExhRjB0MSIsIml2UGFyYW1ldGVyU3BlYyI6Im5LdUlPN01uaXIyZU5Uc28iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D/build/1b990398-160c-419a-93db-182a629b663f).

The PR: https://github.com/geoadmin/web-mapviewer/pull/658

I am not sure though how to test it, since I am not that familiar with OL 9.