### PR TITLE
Don't fail on not supported geometry.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -13,7 +13,7 @@ import VectorLayer from 'ol/layer/Vector.js';
 import VectorSource from 'ol/source/Vector.js';
 import {Circle, Fill, Stroke, Style, Text} from 'ol/style.js';
 import Feature from './ol/Feature.js';
-import {Polygon, LineString, Point} from 'ol/geom.js';
+import {Polygon, LineString, Point, Circle as CircleGeom} from 'ol/geom.js';
 import {getPrintExtent} from './lib/utils.js';
 
 const MFP_URL = 'https://geomapfish-demo-2-8.camptocamp.com/printproxy';
@@ -58,6 +58,10 @@ const features = [
         [796612, 5837460],
       ],
     ]),
+  }),
+  new Feature({
+    name: 'A Circle',
+    geometry: new CircleGeom([796932, 5836860], 75),
   }),
   new Feature({
     name: 'A line',

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -158,27 +158,30 @@ export default class VectorEncoder {
     // features either. To work around this we just ignore the layer if the
     // array of GeoJSON features is empty.
     // See https://github.com/mapfish/mapfish-print/issues/279
-
-    if (geojsonFeatures.length > 0) {
-      // Reorder features: put points last, such that they appear on top
-      geojsonFeatures.sort((feature0, feature1) => {
-        const priority = featureTypePriority_;
-        return priority(feature1) - priority(feature0);
-      });
-
-      const geojsonFeatureCollection = {
-        type: 'FeatureCollection',
-        features: geojsonFeatures,
-      } as GeoJSONFeatureCollection;
-      return {
-        geoJson: geojsonFeatureCollection,
-        opacity: this.layerState_.opacity,
-        style: mapfishStyleObject,
-        type: 'geojson',
-        name: this.layer_.get('name'),
-      };
+    if (geojsonFeatures.length <= 0) {
+      return null;
     }
-    return null;
+    // And if there are no properties except the version in the style, ignore the layer.
+    if (Object.keys(mapfishStyleObject).length <= 1) {
+      return null;
+    }
+    // Reorder features: put points last, such that they appear on top
+    geojsonFeatures.sort((feature0, feature1) => {
+      const priority = featureTypePriority_;
+      return priority(feature1) - priority(feature0);
+    });
+
+    const geojsonFeatureCollection = {
+      type: 'FeatureCollection',
+      features: geojsonFeatures,
+    } as GeoJSONFeatureCollection;
+    return {
+      geoJson: geojsonFeatureCollection,
+      opacity: this.layerState_.opacity,
+      style: mapfishStyleObject,
+      type: 'geojson',
+      name: this.layer_.get('name'),
+    };
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const Constants = {
   DOTS_PER_INCH: 72,
   /** According to the "international yard" definition 1 inch is defined as exactly 2.54 cm. */
   METERS_PER_INCH: 0.0254,
+  /** Vector circles are rendered as polygon of N sides. */
+  CIRCLE_TO_POLYGON_SIDES: 64,
 };
 
 export const CalculatedConstants = {


### PR DESCRIPTION
Fix #26 

Circles are not possible in GeoJson. I encode them as Polygon.
I also split a big method in two and the big deepEqual in tests, because that was hard to debug.