### PR TITLE
Fix encodeWmsLayerState

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -9,12 +9,14 @@ import {
 } from '@geoblocks/mapfishprint';
 import TileLayer from 'ol/layer/Tile.js';
 import OSM from 'ol/source/OSM.js';
+import ImageWMS from 'ol/source/ImageWMS.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import VectorSource from 'ol/source/Vector.js';
 import {Circle, Fill, Stroke, Style, Text} from 'ol/style.js';
 import Feature from './ol/Feature.js';
 import {Polygon, LineString, Point} from 'ol/geom.js';
 import {getPrintExtent} from './lib/utils.js';
+import ImageLayer from 'ol/layer/Image.js';
 
 const MFP_URL = 'https://geomapfish-demo-2-8.camptocamp.com/printproxy';
 const layout = '1 A4 portrait'; // better take from MFP
@@ -77,6 +79,19 @@ features[1].setStyle(getStyleFn('rgba(0,0,0,0.4)'));
 // Features 0 and 1 use dedicated style. Feature 2 uses layer style.
 vectorLayer.getSource().addFeatures(features);
 
+const wmsLayer = new ImageLayer({
+  source: new ImageWMS({
+    url: 'https://wms.geo.admin.ch/',
+    params: {
+      LAYERS: 'ch.astra.wanderland-sperrungen_umleitungen',
+      FORMAT: 'image/png',
+      CRS: 'EPSG:4326',
+      TRANSPARENT: true,
+    },
+    crossOrigin: 'anonymous',
+  }),
+});
+
 const map = new Map({
   target: 'map',
   layers: [
@@ -84,6 +99,7 @@ const map = new Map({
       source: new OSM(),
     }),
     vectorLayer,
+    wmsLayer,
   ],
   view: new View({
     center: [796612, 5836960],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.7",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@geoblocks/print": "0.7.7",
+        "@geoblocks/print": "0.7.8",
         "@geoblocks/recast-utils": "0.1.0",
         "@types/geojson": "7946.0.14",
         "@typescript-eslint/eslint-plugin": "7.3.1",
@@ -25,7 +25,7 @@
         "typescript": "5.4.2"
       },
       "optionalDependencies": {
-        "@geoblocks/print": "0.7"
+        "@geoblocks/print": "0.7.8"
       },
       "peerDependencies": {
         "ol": "7 || 8 || 9"
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@geoblocks/print": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@geoblocks/print/-/print-0.7.7.tgz",
-      "integrity": "sha512-Sv4XcxP+R4lZstv3LT+BBJWP1gefUCO+uGZMkzorf5lCqD4crmf1k1V3dnvY9/UcYW0HeAIg9jPcZ3bMW03OFA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@geoblocks/print/-/print-0.7.8.tgz",
+      "integrity": "sha512-yPMG1fv8DKX8D1qHhibnTOQusCwIy06KVAaZa+FMzuQeUBW5E79C13W5v5DgyJ+Y471adM3vlCibptnxt+XdLA==",
       "dev": true,
       "peerDependencies": {
         "ol": "7 || 8 || 9"

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "doc": "typedoc --name 'Mapfish Print geoblock' --includeVersion --emit docs --excludeExternals --entryPointStrategy expand ./src"
   },
   "optionalDependencies": {
-    "@geoblocks/print": "0.7"
+    "@geoblocks/print": "0.7.8"
   },
   "peerDependencies": {
     "ol": "7 || 8 || 9"
   },
   "devDependencies": {
-    "@geoblocks/print": "0.7.7",
+    "@geoblocks/print": "0.7.8",
     "@geoblocks/recast-utils": "0.1.0",
     "@types/geojson": "7946.0.14",
     "@typescript-eslint/eslint-plugin": "7.3.1",

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -232,7 +232,7 @@ export default class MFPBaseEncoder {
     const layer = layerState.layer;
     console.assert(layer instanceof TileLayer);
     const source = layer.getSource() as TileWMSSource;
-    console.assert(layer instanceof TileWMSSource);
+    console.assert(source instanceof TileWMSSource);
     const urls = source.getUrls();
     console.assert(!!urls);
     return this.encodeWmsLayerState(layerState, urls[0], source.getParams(), customizer);

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -185,7 +185,7 @@ export default class MFPBaseEncoder {
     return {
       name: layer.get('name'),
       baseURL: url,
-      imageFormat: 'image/png',
+      imageFormat: params.FORMAT,
       layers: params.LAYERS.split(','),
       customParams: {},
       serverType: 'mapserver',

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -169,7 +169,7 @@ export default class MFPBaseEncoder {
   encodeImageWmsLayerState(layerState: State, customizer: BaseCustomizer) {
     const layer = layerState.layer;
     const source = layer.getSource() as ImageWMSSource;
-    console.assert(layer instanceof ImageWMSSource);
+    console.assert(source instanceof ImageWMSSource);
     const url = source.getUrl();
     if (url !== undefined) {
       return this.encodeWmsLayerState(layerState, url, source.getParams(), customizer);
@@ -186,7 +186,7 @@ export default class MFPBaseEncoder {
       name: layer.get('name'),
       baseURL: url,
       imageFormat: 'image/png',
-      layers: [''],
+      layers: params.LAYERS.split(','),
       customParams: {},
       serverType: 'mapserver',
       type: 'wms',


### PR DESCRIPTION
- Set value of `layers` and `imageFormat` from `params`
- Fix wrong assertions
- Update `geoblocks/print` to remove the following warning
```
npm i --save-dev vite@latest              
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @geoblocks/print@0.7.4
npm WARN Found: ol@9.0.0
npm WARN node_modules/ol
npm WARN   peer ol@"7 || 8 || 9" from @geoblocks/mapfishprint@0.2.7
npm WARN   node_modules/@geoblocks/mapfishprint
npm WARN     @geoblocks/mapfishprint@"^0.2.7" from the root project
npm WARN   2 more (@geoblocks/ol-maplibre-layer, the root project)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer ol@"6 || 7 || 8" from @geoblocks/print@0.7.4
npm WARN node_modules/@geoblocks/print
npm WARN   optional @geoblocks/print@"0.7" from @geoblocks/mapfishprint@0.2.7
npm WARN   node_modules/@geoblocks/mapfishprint
npm WARN 
npm WARN Conflicting peer dependency: ol@8.2.0
npm WARN node_modules/ol
npm WARN   peer ol@"6 || 7 || 8" from @geoblocks/print@0.7.4
npm WARN   node_modules/@geoblocks/print
npm WARN     optional @geoblocks/print@"0.7" from @geoblocks/mapfishprint@0.2.7
npm WARN     node_modules/@geoblocks/mapfishprint
```