### PR TITLE
Fix matrix size on WMTS layer.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function getWmtsMatrices(source: WMTS): MFPWmtsMatrix[] {
       scaleDenominator: resolutionMeters / Constants.WMTS_PIXEL_SIZE,
       tileSize: toSize(tileGrid.getTileSize(i)),
       topLeftCorner: tileGrid.getOrigin(i),
-      matrixSize: [tileRange.maxX - tileRange.minX, tileRange.maxY - tileRange.minY],
+      matrixSize: [tileRange.maxX - tileRange.minX + 1, tileRange.maxY - tileRange.minY + 1],
     } as MFPWmtsMatrix);
   }
 


### PR DESCRIPTION
It fixes this issue, an empty space in the end of the map:
![image](https://github.com/geoblocks/mapfishprint/assets/1421861/5d78c0a5-566e-41bb-a32d-ef7aa8d70c38)

After the fix:
![image](https://github.com/geoblocks/mapfishprint/assets/1421861/3b05ca38-d76d-4b56-ad5d-5d919781311a)
