### PR TITLE
Added WMS custom params and WMS customizer entry point

### DIFF
--- a/src/BaseCustomizer.ts
+++ b/src/BaseCustomizer.ts
@@ -1,8 +1,8 @@
 import type {Geometry} from 'ol/geom.js';
 import type {State} from 'ol/layer/Layer.js';
-import type {WMTS} from 'ol/source.js';
+import type {WMTS, TileWMS} from 'ol/source.js';
 import type {Image, Stroke} from 'ol/style.js';
-import type {MFPSymbolizerLine, MFPSymbolizerPoint, MFPWmtsLayer} from './types';
+import type {MFPWmsLayer, MFPSymbolizerLine, MFPSymbolizerPoint, MFPWmtsLayer} from './types';
 import type {Feature as GeoJSONFeature} from 'geojson';
 
 /**
@@ -80,4 +80,12 @@ export default class BaseCustomizer {
   wmtsLayer(layerState: State, wmtsLayer: MFPWmtsLayer, source: WMTS) {}
   // FIXME: does it really makes sense?
   // Why isn't it done on an extended BaseEncoder instead?
+
+  /**
+   * Can be used to manipulate a converted WMS layer
+   * @param layerState
+   * @param wmsLayer
+   * @param source
+   */
+  wmsLayer(layerState: State, wmsLayer: MFPWmsLayer, source: TileWMS) {}
 }

--- a/src/MFPEncoder.ts
+++ b/src/MFPEncoder.ts
@@ -182,18 +182,23 @@ export default class MFPBaseEncoder {
    */
   encodeWmsLayerState(layerState: State, url: string, params: any, customizer: BaseCustomizer): MFPWmsLayer {
     const layer = layerState.layer;
+    // Pass all WMS params, but not the one standard one that are handled by mapfishprint
+    const customParams: any = {...params};
+    ['SERVICE', 'REQUEST', 'FORMAT', 'LAYERS', 'VERSION', 'STYLES'].forEach(
+      (p: string) => delete customParams[p],
+    );
     return {
       name: layer.get('name'),
       baseURL: url,
       imageFormat: params.FORMAT,
       layers: params.LAYERS.split(','),
-      customParams: {},
+      customParams,
       serverType: 'mapserver',
       type: 'wms',
       opacity: layer.getOpacity(),
       version: params.VERSION,
       useNativeAngle: true,
-      styles: [''],
+      styles: params.STYLES?.split(',') ?? [''],
     };
   }
 
@@ -235,7 +240,9 @@ export default class MFPBaseEncoder {
     console.assert(source instanceof TileWMSSource);
     const urls = source.getUrls();
     console.assert(!!urls);
-    return this.encodeWmsLayerState(layerState, urls[0], source.getParams(), customizer);
+    const wmsLayer = this.encodeWmsLayerState(layerState, urls[0], source.getParams(), customizer);
+    customizer.wmsLayer(layerState, wmsLayer, source);
+    return wmsLayer;
   }
 
   /**


### PR DESCRIPTION
Pass all Openlayer WMS params to the custom params per default and added also wms to the customizer so that the user can change any param if he wants to.

This solve the issue for TIME layer as well as for TRANSPARENT=true layer in openlayer that needs to pass these parameters as well to print in order to have them printed the same was as they are rendered in ol.