### PR TITLE
Fix wrong direction of text Y axis offset.

### DIFF
--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -523,7 +523,8 @@ export default class VectorEncoder {
         label: textStyle.getText(),
         fontFamily: textStyle.getFont() ? textStyle.getFont() : 'sans-serif',
         labelXOffset: textStyle.getOffsetX(),
-        labelYOffset: textStyle.getOffsetY(),
+        // OL and MFP behaves differently on the Y offset
+        labelYOffset: -textStyle.getOffsetY(),
         labelAlign: 'cm',
       } as MFPSymbolizerText;
       const fillStyle = textStyle.getFill();

--- a/test.js
+++ b/test.js
@@ -79,7 +79,7 @@ const styleFn = (feature) => {
     text: new Text({
       text: feature.get('name'),
       font: '12px sans-serif',
-      offsetY: 12,
+      offsetY: -12,
     }),
     image: new Circle({
       fill,


### PR DESCRIPTION
- OpenLayers: https://openlayers.org/en/latest/apidoc/module-ol_style_Text-Text.html
   - **offsetY**: Vertical text offset in pixels. A positive will shift the text down.
- MFP: https://mapfish.github.io/mapfish-print-doc/styles.html
  - **labelYOffset** (ECQL) - (Point Placement) the amount to offset the label along the y axis. negative number offset to the top of the printing

UPDATE:

It seems there might be a confusion in myself.

From the documentation itself, both description above seems the same. But when I try to print, there is an unexpected result