### PR TITLE
Support function in geometries:

### DIFF
--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -187,34 +187,31 @@ export default class VectorEncoder {
       // handling more cases than we actually do
       let geometry: any = style.getGeometry();
       let geojsonFeature;
-      // In some cases, the geometries are objects, in other cases they're features.
-      // We need to make sure that either the geometry is an object, or that the feature it contains returns
-      // a non-null / non-undefined value.
-      if (geometry && ((typeof geometry === 'object' && geometry instanceof Object) || (typeof geometry === 'function' && geometry(feature))) {
-        const styledFeature = feature.clone();
-        if (geometry instanceof Object && typeof geometry === 'object') {
+      // In some cases, the geometries are objects, in other cases they're functions.
+      // we need to ensure we're handling functions, wether they return an object or not.
+      if (typeof geometry === 'function') {
+          geometry = geometry(feature);
+        }
+        if (typeof geometry === 'object') {
+          const styledFeature = feature.clone();
           styledFeature.setGeometry(geometry);
-        }
-        else {
-          styledFeature.setGeometry(geometry(feature));
-        }
-        geojsonFeature = this.geojsonFormat.writeFeatureObject(styledFeature);
-        geojsonFeatures.push(geojsonFeature);
-      } else {
-        geojsonFeature = origGeojsonFeature;
-        geometry = feature.getGeometry();
-        // no need to encode features with no geometry
-        if (!geometry) {
-          return;
-        }
-        if (!this.customizer_.geometryFilter(geometry)) {
-          return;
-        }
-        if (!isOriginalFeatureAdded) {
+          geojsonFeature = this.geojsonFormat.writeFeatureObject(styledFeature);
           geojsonFeatures.push(geojsonFeature);
-          isOriginalFeatureAdded = true;
+        } else {
+          geojsonFeature = origGeojsonFeature;
+          geometry = feature.getGeometry();
+          // no need to encode features with no geometry
+          if (!geometry) {
+            return;
+          }
+          if (!this.customizer_.geometryFilter(geometry)) {
+            return;
+          }
+          if (!isOriginalFeatureAdded) {
+            geojsonFeatures.push(geojsonFeature);
+            isOriginalFeatureAdded = true;
+          }
         }
-      }
 
       this.addVectorStyle(mapfishStyleObject, geojsonFeature, style);
     });

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -190,7 +190,7 @@ export default class VectorEncoder {
       // In some cases, the geometries are objects, in other cases they're features.
       // We need to make sure that either the geometry is an object, or that the feature it contains returns
       // a non-null / non-undefined value.
-      if (geometry && ((geometry instanceof Object && typeof geometry === 'object') || geometry(feature))) {
+      if (geometry && ((typeof geometry === 'object' && geometry instanceof Object) || (typeof geometry === 'function' && geometry(feature))) {
         const styledFeature = feature.clone();
         if (geometry instanceof Object && typeof geometry === 'object') {
           styledFeature.setGeometry(geometry);

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -187,9 +187,17 @@ export default class VectorEncoder {
       // handling more cases than we actually do
       let geometry: any = style.getGeometry();
       let geojsonFeature;
-      if (geometry) {
+      // In some cases, the geometries are objects, in other cases they're features.
+      // We need to make sure that either the geometry is an object, or that the feature it contains returns
+      // a non-null / non-undefined value.
+      if (geometry && ((geometry instanceof Object && typeof geometry === 'object') || geometry(feature))) {
         const styledFeature = feature.clone();
-        styledFeature.setGeometry(geometry);
+        if (geometry instanceof Object && typeof geometry === 'object') {
+          styledFeature.setGeometry(geometry);
+        }
+        else {
+          styledFeature.setGeometry(geometry(feature));
+        }
         geojsonFeature = this.geojsonFormat.writeFeatureObject(styledFeature);
         geojsonFeatures.push(geojsonFeature);
       } else {


### PR DESCRIPTION
- Issue : in some cases, the style.getGeometry() function would return a function rather than an object, causing issues when trying to set the geometry later in the code as we were calling geometry(undefined) instead of geometry(feature).

- Fix : we check that the geometry is either an object, or a function which returns a non-null / non-undefined value, and we also use the function the geometry contains when it's not an Object.