### PR TITLE
Add optional lang attribute to print spec

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface MFPSpec {
   attributes: Partial<MFPAttributes>;
   layout: string;
   format: string;
+  lang?: string;
   smtp?: Record<string, string>;
 }
 


### PR DESCRIPTION
Needed to send the current language the MapFishPrint from GeoGirafe interface.