### PR TITLE
Add safety around font parameters

### DIFF
--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -558,14 +558,14 @@ export default class VectorEncoder {
   ) {
     const label = textStyle.getText();
     if (label) {
-      const fp = getFontParameters(textStyle.getFont() || 'sans-serif');
+      const fp = getFontParameters(textStyle.getFont() || '12px sans-serif');
       const symbolizer = {
         type: 'text',
         label: textStyle.getText(),
-        fontFamily: fp.family,
-        fontSize: fp.size,
-        fontStyle: fp.style,
-        fontWeight: fp.weight,
+        fontFamily: fp?.family ?? 'sans-serif',
+        fontSize: fp?.size ?? '12px',
+        fontStyle: fp?.style ?? 'normal',
+        fontWeight: fp?.weight ?? 'normal',
         // FIXME: missing fontVariant, is it supported in MFP?
         labelXOffset: textStyle.getOffsetX(),
         // OL and MFP behaves differently on the Y offset


### PR DESCRIPTION
Issue : The `getFontParameters` function can return `null`, and the current implementation is not guaranteed to return an item. This cause issues when there are label that need to be printed.

Fix : We add the font size in the default font string (as it is necessary to the regex). We also ensure we have default values in case the regex within `getFontParameters` does not manage to parse anything (for example, it can't parse numbers in font names)