### PR TITLE
Fix printing circles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
-# @geoblocks/mapfisprint changes
+# @geoblocks/mapfishprint changes
+
+## 0.2.23
+
+- Resolve a bug where a style with its own geometry as a Circle was transformed into a GeometryCollection resulting in an error
+
+Breaking changes:
+
+- VectorEncoder.featureCircleAsPolygon() was removed.
 
 ## 0.2.20
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # @geoblocks/mapfishprint changes
 
-## 0.2.23
+## 1.0.0
 
 - Resolve a bug where a style with its own geometry as a Circle was transformed into a GeometryCollection resulting in an error
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # @geoblocks/mapfishprint changes
 
-## 1.0.0
+## 0.3.0
 
 - Resolve a bug where a style with its own geometry as a Circle was transformed into a GeometryCollection resulting in an error
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoblocks/mapfishprint",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoblocks/mapfishprint",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@geoblocks/print": "0.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoblocks/mapfishprint",
-  "version": "0.2.23",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoblocks/mapfishprint",
-      "version": "0.2.23",
+      "version": "1.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@geoblocks/print": "0.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblocks/mapfishprint",
-  "version": "0.2.23",
+  "version": "1.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblocks/mapfishprint",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblocks/mapfishprint",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -188,7 +188,7 @@ export default class VectorEncoder {
           geometry = feature.getGeometry();
       }
       if (geometry.getType() === "Circle") {
-        geometry = this.featureCircleAsPolygon(feature as Feature<Circle>).getGeometry();
+        geometry = fromCircle((feature as Feature<Circle>).getGeometry(), Constants.CIRCLE_TO_POLYGON_SIDES);
       }
       let geojsonFeature;
       // In some cases, the geometries are objects, in other cases they're functions.

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -601,15 +601,4 @@ export default class VectorEncoder {
       symbolizers.push(symbolizer);
     }
   }
-
-  /**
-   * Converts a circle feature to a N sides polygon feature.
-   * Sides are defined in Constants.CIRCLE_TO_POLYGON_SIDES.
-   */
-  protected featureCircleAsPolygon(feature: Feature<Circle>) {
-    return new Feature({
-      ...feature.getProperties(),
-      geometry: fromCircle(feature.getGeometry(), Constants.CIRCLE_TO_POLYGON_SIDES),
-    });
-  }
 }

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -167,9 +167,6 @@ export default class VectorEncoder {
     if (styleFunction) {
       styleData = styleFunction(feature, resolution) as null | Style | Style[];
     }
-    if (feature.getGeometry().getType() === 'Circle') {
-      feature = this.featureCircleAsPolygon(feature as Feature<Circle>);
-    }
     const origGeojsonFeature = this.geojsonFormat.writeFeatureObject(feature);
 
     let styles = styleData !== null && !Array.isArray(styleData) ? [styleData] : (styleData as Style[]);
@@ -186,6 +183,13 @@ export default class VectorEncoder {
       // FIXME: the return of the function is very complicate and would require
       // handling more cases than we actually do
       let geometry: any = style.getGeometry();
+      // Fallback to the feature geometry if style doesn't give one.
+      if (geometry === null) {
+          geometry = feature.getGeometry();
+      }
+      if (geometry.getType() === "Circle") {
+        geometry = this.featureCircleAsPolygon(feature as Feature<Circle>).getGeometry();
+      }
       let geojsonFeature;
       // In some cases, the geometries are objects, in other cases they're functions.
       // we need to ensure we're handling functions, wether they return an object or not.
@@ -200,7 +204,6 @@ export default class VectorEncoder {
         geojsonFeatures.push(geojsonFeature);
       } else {
         geojsonFeature = origGeojsonFeature;
-        geometry = feature.getGeometry();
         // no need to encode features with no geometry
         if (!geometry) {
           return;

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -167,6 +167,11 @@ export default class VectorEncoder {
     if (styleFunction) {
       styleData = styleFunction(feature, resolution) as null | Style | Style[];
     }
+
+    const featureGeometry = feature.getGeometry();
+    if (featureGeometry.getType() === "Circle") {
+      feature.setGeometry(fromCircle(featureGeometry as Circle, Constants.CIRCLE_TO_POLYGON_SIDES));
+    }
     const origGeojsonFeature = this.geojsonFormat.writeFeatureObject(feature);
 
     let styles = styleData !== null && !Array.isArray(styleData) ? [styleData] : (styleData as Style[]);
@@ -185,18 +190,21 @@ export default class VectorEncoder {
       let geometry: any = style.getGeometry();
       // Fallback to the feature geometry if style doesn't give one.
       if (geometry === null) {
-          geometry = feature.getGeometry();
+        geometry = featureGeometry;
       }
-      if (geometry.getType() === "Circle") {
-        geometry = fromCircle((feature as Feature<Circle>).getGeometry(), Constants.CIRCLE_TO_POLYGON_SIDES);
-      }
-      let geojsonFeature;
       // In some cases, the geometries are objects, in other cases they're functions.
       // we need to ensure we're handling functions, wether they return an object or not.
       if (typeof geometry === 'function') {
         geometry = geometry(feature);
       }
-      if (geometry && typeof geometry === 'object') {
+      // no need to encode features with no geometry
+      if (!geometry) return;
+
+      if (geometry.getType() === "Circle") {
+        geometry = fromCircle(geometry as Circle, Constants.CIRCLE_TO_POLYGON_SIDES);
+      }
+      let geojsonFeature;
+      if (typeof geometry === 'object') {
         // note that (typeof null === 'object')
         const styledFeature = feature.clone();
         styledFeature.setGeometry(geometry);
@@ -204,10 +212,6 @@ export default class VectorEncoder {
         geojsonFeatures.push(geojsonFeature);
       } else {
         geojsonFeature = origGeojsonFeature;
-        // no need to encode features with no geometry
-        if (!geometry) {
-          return;
-        }
         if (!this.customizer_.geometryFilter(geometry)) {
           return;
         }

--- a/src/VectorEncoder.ts
+++ b/src/VectorEncoder.ts
@@ -169,7 +169,10 @@ export default class VectorEncoder {
     }
 
     const featureGeometry = feature.getGeometry();
-    if (featureGeometry.getType() === "Circle") {
+    if (featureGeometry.getType() === 'Circle') {
+      const featureId = feature.getId();
+      feature = feature.clone();
+      feature.setId(featureId);
       feature.setGeometry(fromCircle(featureGeometry as Circle, Constants.CIRCLE_TO_POLYGON_SIDES));
     }
     const origGeojsonFeature = this.geojsonFormat.writeFeatureObject(feature);
@@ -200,7 +203,7 @@ export default class VectorEncoder {
       // no need to encode features with no geometry
       if (!geometry) return;
 
-      if (geometry.getType() === "Circle") {
+      if (geometry.getType() === 'Circle') {
         geometry = fromCircle(geometry as Circle, Constants.CIRCLE_TO_POLYGON_SIDES);
       }
       let geojsonFeature;

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import Map from 'ol/Map.js';
-import {MFPEncoder, BaseCustomizer} from './lib/index.js';
+import {MFPEncoder, MFPVectorEncoder, BaseCustomizer} from './lib/index.js';
 import TileLayer from 'ol/layer/Tile.js';
 import OSM from 'ol/source/OSM.js';
 import {View} from 'ol';
@@ -321,6 +321,49 @@ test('Vector features', async (t) => {
           fontColor: '#333333',
         },
       ],
+    },
+  });
+});
+
+test('MFPVectorEncoder can encode a circle with a circel in its style.geometry', async (t) => {
+  const geomStyleFn = () => {
+    return new Style({
+      geometry: fCircle.getGeometry(),
+      fill,
+      stroke
+    });
+  };
+  fCircle.setStyle(geomStyleFn);
+  const vectorLayer = new VectorLayer({
+    source: new VectorSource({
+      features: [fCircle],
+    }),
+  });
+  const customizer = new BaseCustomizer();
+  const resolution = 1.0583354500042335;
+  const encodedSpecialLayer = new MFPVectorEncoder(vectorLayer.getLayerState(), customizer).encodeVectorLayer(resolution);
+
+  assert.deepEqual(encodedSpecialLayer.geoJson.features[0], {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [796622, 5836960],
+          [796619.0710678119, 5836967.071067812],
+          [796612, 5836970],
+          [796604.9289321881, 5836967.071067812],
+          [796602, 5836960],
+          [796604.9289321881, 5836952.928932188],
+          [796612, 5836950],
+          [796619.0710678119, 5836952.928932188],
+          [796622, 5836960],
+        ],
+      ],
+    },
+    properties: {
+      name: 'A circle',
+      _mfp_style: '1',
     },
   });
 });

--- a/test.js
+++ b/test.js
@@ -325,7 +325,7 @@ test('Vector features', async (t) => {
   });
 });
 
-test('MFPVectorEncoder can encode a circle with a circel in its style.geometry', async (t) => {
+test('MFPVectorEncoder can encode a circle with a circle in its style.geometry', async (t) => {
   const geomStyleFn = () => {
     return new Style({
       geometry: fCircle.getGeometry(),

--- a/test.js
+++ b/test.js
@@ -330,7 +330,7 @@ test('MFPVectorEncoder can encode a circle with a circle in its style.geometry',
     return new Style({
       geometry: fCircle.getGeometry(),
       fill,
-      stroke
+      stroke,
     });
   };
   fCircle.setStyle(geomStyleFn);
@@ -341,7 +341,9 @@ test('MFPVectorEncoder can encode a circle with a circle in its style.geometry',
   });
   const customizer = new BaseCustomizer();
   const resolution = 1.0583354500042335;
-  const encodedSpecialLayer = new MFPVectorEncoder(vectorLayer.getLayerState(), customizer).encodeVectorLayer(resolution);
+  const encodedSpecialLayer = new MFPVectorEncoder(vectorLayer.getLayerState(), customizer).encodeVectorLayer(
+    resolution,
+  );
 
   assert.deepEqual(encodedSpecialLayer.geoJson.features[0], {
     type: 'Feature',


### PR DESCRIPTION
This PR fixes an issue where a Circle was converted to a FeatureCollection and not printed at all.

You can reproduce the bug here:
- https://demo.geomapfish.dev/sitn
- draw a circle
- try to print -> error

These modifications allow to keep the original style of the circle and just convert the geometry